### PR TITLE
to deploy 

### DIFF
--- a/resources/views/reports/sections/monthlydepreciation.blade.php
+++ b/resources/views/reports/sections/monthlydepreciation.blade.php
@@ -1310,7 +1310,7 @@
                             toastr.success(response.data.message);
                             this.newSub = response.data.data;
                             this.subsidiaries.dynamic = []
-                           // window.reload();
+                            window.reload();
                         }).catch(err => {
                             console.error(err)
                         })
@@ -1520,10 +1520,6 @@
                             
                             this.$set(updated, "amort", newBalance);
                             updated.due_amort = Number(this.newRemBalance.replace(/[^0-9\.-]+/g, ""));
-                            updated.used = (parseInt(updated.used) || 0) + (parseInt(this.sub.rem) || 0);
-                            updated.rem = (parseInt(updated.sub_no_depre || 0)) - (parseInt(updated.used) || 0);
-                            updated.unexpensed = (parseInt(updated.unexpensed || 0)) - newBalance;
-
                             const newArray = [...rows];
                             newArray[index] = updated;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Depreciation postings now use the selected period’s end date, adjusted to the next business day when it falls on a weekend, ensuring accurate payment dates.
  - Scheduled depreciation entries now timestamp with the period’s “as of” date for consistency.
  - After submitting Monthly Depreciation, the page reloads to reflect the latest totals.
  - Payment processing updates amortization amounts only; other summary fields remain unchanged to avoid showing incorrect interim values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->